### PR TITLE
Fix warnings about obj in domain

### DIFF
--- a/sphinxcontrib/jinjadomain.py
+++ b/sphinxcontrib/jinjadomain.py
@@ -102,7 +102,7 @@ class JinjaDomain(Domain):
     name = "jinja"
     label = "jinja"
 
-    object_types = {"template": ObjType("template", "template", "obj")}
+    object_types = {"template": ObjType("template", "template")}
 
     directives = {"template": JinjaResource}
 

--- a/sphinxcontrib/jinjadomain.py
+++ b/sphinxcontrib/jinjadomain.py
@@ -30,7 +30,6 @@ class JinjaResource(ObjectDescription):
             "parameter",
             label="Parameters",
             names=("param", "parameter", "arg", "argument"),
-            typerolename="obj",
             typenames=("paramtype", "type"),
         )
     ]


### PR DESCRIPTION
Without the change the ComplainceAsCode/content has 500+ warnigns with this change it goes to around 170 warnings.  

Based on sphinx-contrib/httpdomain/pull/54